### PR TITLE
Add UPF Subscribers upload bitrate metric

### DIFF
--- a/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
+++ b/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
@@ -50,7 +50,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 3,
         "x": 0,
         "y": 0
@@ -136,7 +136,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 3,
         "x": 3,
         "y": 0
@@ -223,7 +223,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 3,
         "x": 6,
         "y": 0
@@ -310,7 +310,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 15,
         "x": 9,
         "y": 0
@@ -363,6 +363,7 @@
     },
     {
       "datasource": null,
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -411,7 +412,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 6
       },
       "id": 12,
       "options": {
@@ -446,6 +447,86 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "UPF Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 13,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.11",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(8 * irate(upf_session_tx_bytes{namespace=\"omec\"}[1m])) by (ue_ip)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{ue_ip}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "UPF Subscribers Upload Bitrate",
       "type": "timeseries"
     }
   ],


### PR DESCRIPTION
This PR simply adds a graph for the upload bitrate of the UPF subscribers, as exported by the UPF itself. As of now, the UPF only exports the UE sessions uplink bytes, no downlink bytes metric yet.

Preview of the Dashboard:
<img width="1853" alt="Screenshot 2023-11-16 at 18 25 09" src="https://github.com/opennetworkinglab/aether-amp/assets/30477293/06aa089b-fa87-49ba-909a-daba31dc07ec">
