### PR TITLE
Add download bandwidth metric to UPF Subscribers

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,10 @@
+[ssh_connection]
+ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=5m -o LogLevel=QUIET -o ForwardAgent=yes"
+control_path = /tmp/ansible-%%r@%%h:%%p
+
+[defaults]
+forks = 48
+pipelining = True
+host_key_checking = False
+deprecation_warnings=False
+hash_behaviour=merge

--- a/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
+++ b/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
@@ -497,7 +497,7 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 15
       },
@@ -517,9 +517,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(8 * irate(upf_session_tx_bytes{namespace=\"omec\"}[1m])) by (ue_ip)",
+          "expr": "sum(8 * irate(upf_session_tx_bytes{namespace=\"omec\",pdr=~\".*[13579]\"}[2m])) by (ue_ip)",
           "hide": false,
           "interval": "",
+          "intervalFactor": 1,
           "legendFormat": "{{ue_ip}}",
           "refId": "A"
         }
@@ -527,6 +528,88 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "UPF Subscribers Upload Bitrate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-yellow",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 14,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.11",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(8 * irate(upf_session_tx_bytes{namespace=\"omec\",pdr=~\".*[02468]\"}[1m])) by (ue_ip)",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ue_ip}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "UPF Subscribers Download Bitrate",
       "type": "timeseries"
     }
   ],
@@ -538,7 +621,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},

--- a/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
+++ b/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
@@ -599,7 +599,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(8 * irate(upf_session_tx_bytes{namespace=\"omec\",pdr=~\".*[02468]\"}[1m])) by (ue_ip)",
+          "expr": "sum(8 * irate(upf_session_tx_bytes{namespace=\"omec\",pdr=~\".*[02468]\"}[2m])) by (ue_ip)",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
@@ -621,7 +621,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
This PR add the download bandwidth metrics to the Grafana dashboard.
Although the metric exported by the UPF has the name `upf_session_tx_bytes` (which would indicate only tx stream is being measured), in actuality, for each UE session, the UPF exports two PDR labels, one for the uplink and other for the downlink flow.

The pair of PDR labels values are increased for each session created, but the even/odd values always represent the download/upload flow respectively, so the query filters these values via REGEX pattern.

Preview of the Dashboard:
<img width="1639" alt="Screenshot 2024-01-10 at 15 49 25" src="https://github.com/opennetworkinglab/aether-amp/assets/30477293/c6cc98ca-c619-4ad1-988c-fc2b8ba9ac9c">

Note: Also added the `ansible.cfg` file that was missing from the repo.
