### PR TITLE
Add the IP address of each subscriber

### DIFF
--- a/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
+++ b/roles/monitor-load/templates/5g-monitoring/aiab5g-dashboard.json
@@ -80,7 +80,7 @@
           },
           "editorMode": "builder",
           "exemplar": true,
-          "expr": "smf_pdu_sessions",
+          "expr": "smf_pdu_sessions{service=\"metricfunc\"}",
           "hide": false,
           "instant": true,
           "interval": "",
@@ -307,7 +307,20 @@
           },
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "imsi"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 214
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 6,
@@ -317,7 +330,9 @@
       },
       "id": 6,
       "options": {
-        "showHeader": true
+        "frameIndex": 1,
+        "showHeader": true,
+        "sortBy": []
       },
       "pluginVersion": "7.5.11",
       "targets": [
@@ -336,6 +351,16 @@
           "legendFormat": "",
           "range": true,
           "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum without (id) (label_replace(smf_pdu_session_profile, \"imsi\", \"$1\", \"id\", \"(.*)\"))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -343,18 +368,55 @@
       "title": "5G Core Subscribers",
       "transformations": [
         {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "imsi"
+          }
+        },
+        {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true,
-              "Value": true
+              "Time 1": true,
+              "Time 2": true,
+              "Value #A": true,
+              "Value #B": true,
+              "endpoint": true,
+              "enterprise": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "pod": true,
+              "service": true,
+              "state 1": false,
+              "state 2": true,
+              "upf": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "Time 1": 1,
+              "Time 2": 4,
+              "Value #A": 3,
+              "Value #B": 15,
+              "endpoint": 5,
+              "enterprise": 6,
+              "imsi": 0,
+              "instance": 7,
+              "ip": 8,
+              "job": 9,
+              "namespace": 10,
+              "pod": 11,
+              "service": 12,
+              "slice": 2,
+              "state 1": 16,
+              "state 2": 13,
+              "upf": 14
+            },
             "renameByName": {
-              "Value": "Status",
               "imsi": "IMSI",
+              "ip": "IP Address",
               "slice": "Slice",
-              "state": "State"
+              "state 1": "State"
             }
           }
         }

--- a/roles/monitor-load/templates/5g-monitoring/kustomization.yaml
+++ b/roles/monitor-load/templates/5g-monitoring/kustomization.yaml
@@ -5,6 +5,7 @@
 resources:
   - ./metricfunc-monitor.yaml
   - ./upf-monitor.yaml
+  - ./smf-monitor.yaml
 
 configMapGenerator:
   - name: grafana-ops-dashboards

--- a/roles/monitor-load/templates/5g-monitoring/smf-monitor.yaml
+++ b/roles/monitor-load/templates/5g-monitoring/smf-monitor.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022-present Intel Corporation
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: smf
+  namespace: omec
+spec:
+  endpoints:
+    - path: /metrics
+      port: prometheus-exporter
+  namespaceSelector:
+    matchNames:
+      - omec
+  selector:
+    matchLabels:
+      app: smf


### PR DESCRIPTION
This PR add the IP address of each subscriber to the Grafana Dashboard. Since the [metricfunc](https://github.com/omec-project/metricfunc) pod does not give that information directly, we must get the IP addresses from the SMF pod directly.
For that, a ServiceMonitor is created for the SMF pod `(smf-monitor)`, which is then loaded to the `kustomization.yaml` file.
Some changes were required in the Dashboard logic itself to serve the information.

Preview:
<img width="1633" alt="Screenshot 2024-01-11 at 14 25 16" src="https://github.com/opennetworkinglab/aether-amp/assets/30477293/03dbb055-c9ca-464d-b13d-44dec9bc4147">
