### PR TITLE
Update namespace for additional UPFs

### DIFF
--- a/roles/roc-load/templates/roc-5g-models-upf2.json
+++ b/roles/roc-load/templates/roc-5g-models-upf2.json
@@ -130,11 +130,11 @@
                 ],
                 "upf": [
                     {
-                        "address": "upf.aether-5gc-upf-1",
+                        "address": "upf.aether-upf-1",
                         "display-name": "Aether UPF 2",
                         "upf-id": "upf-2",
                         "port": 8805,
-                        "config-endpoint": "http://upf-http.aether-5gc-upf-1.svc:8080"
+                        "config-endpoint": "http://upf-http.aether-upf-1.svc:8080"
                     }
                 ]
             }


### PR DESCRIPTION
Namespace for additional UPFs was updated in Kubernetes (5gc blueprint) but that update was not reflected here in `amp` blueprint